### PR TITLE
Overload SetLocation in telemetrypacket to take only lat and long

### DIFF
--- a/GS/TelemetryPacket.cpp
+++ b/GS/TelemetryPacket.cpp
@@ -55,6 +55,12 @@ void Protocol::TelemetryPacket::SetLocation(double lat, double lon, float alt)
 	this->alt = alt;
 }
 
+void Protocol::TelemetryPacket::SetLocation(double lat, double lon)
+{
+	this->lat = lat;
+	this->lon = lon;
+}
+
 void Protocol::TelemetryPacket::SetHeading(float h)
 {
 	this->heading = h;

--- a/GS/messagebox.cpp
+++ b/GS/messagebox.cpp
@@ -9,8 +9,22 @@ messagebox::messagebox()
 
 }
 
+/* Uses code from MapExecution::getDoublePairs
+takes input from MapPlanning::getTableAsStrings()
+-Aaron Ko 1/19/2016 */
 void messagebox::fetch_from_table(QList<std::string> tableList){
-
+    for(QString string : tableList){
+        QList<QString> comps = string.split(",");
+        double lat = comps[3].toDouble();
+        double lon = comps[1].toDouble();
+        if(comps[2] == "W") {
+            lng *= -1.0;
+        }
+        if(comps[4] == "S") {
+            lat *= -1.0;
+        }
+        load_telem_packet(lat, lon);
+    }
 }
 
 void messagebox::load_ack_packet(uint8_t* buffer, size_t len){
@@ -31,6 +45,11 @@ void messagebox::loack_action_packet(Protocol::ActionType at, double lat, double
 void messagebox::load_info_packet(std::string other){
     infoPackets.push_back(Protocol::InfoPacket());
     infoPackets.back().SetOther(other);
+}
+
+void messagebox::load_telem_packet(double lat, double lon){
+    telemetryPackets.push_back(Protocol::TelemetryPacket());
+    telemetryPackets.back().SetLocation(lat, lon, alt);
 }
 
 void messagebox::load_telem_packet(float x, float y, float z, float p, float r, float yaw, double lat, double lon, float alt, float heading){

--- a/GS/messagebox.h
+++ b/GS/messagebox.h
@@ -35,6 +35,7 @@ public:
     void load_ack_packet(uint8_t* buffer, size_t len);
     void loack_action_packet(Protocol::ActionType at, double lat, double lon, float alt, float spd);
     void load_info_packet(std::string other);
+    void load_telem_packet(double lat, double lon);
     void load_telem_packet(float x, float y, float z, float p, float r, float yaw, double lat, double lon, float alt, float heading);
     std::vector<Protocol::AckPacket> get_ack_packets();
     std::vector<Protocol::ActionPacket> get_action_packets();

--- a/GS/telemetrypacket.h
+++ b/GS/telemetrypacket.h
@@ -50,6 +50,8 @@ namespace Protocol
 
 		void SetLocation(double lat, double lon, float alt);
 
+		void SetLocation(double lat, double lon);
+
 		void SetHeading(float h);
 
 		void GetVelocity(float* x, float* y, float* z);


### PR DESCRIPTION
Overload load_telem_packet in messagebox to only take lat and long

Messagebox:fetch_from_table takes string from
QList<QString> MapPlanning::getTableAsStrings()
and ads a telem packet with lat and long for each waypoint